### PR TITLE
Add ability to specify S3 storage class for uploaded files

### DIFF
--- a/drivers/S3/S3.php
+++ b/drivers/S3/S3.php
@@ -19,6 +19,7 @@ class S3 extends FlysystemBase
 		"region" => '',
 		'immortal' => '',
 		'path' => '',
+		'storageclass' => '',
 		'customendpoint' => '',
 		'customregion' => '',
 		'enabled' => 'yes',
@@ -60,10 +61,22 @@ class S3 extends FlysystemBase
 				'South America (São Paulo)' => 'sa-east-1',
 				'Middle East (Bahrain)' => 'me-south-1',
 			];
+		$storageclasses = [
+				'Standard' => 'STANDARD',
+				'Intelligent-Tiering' => 'INTELLIGENT_TIERING',
+				'Express One Zone' => 'EXPRESS_ONEZONE',
+				'Standard-Infrequent Access' => 'STANDARD_IA',
+				'One Zone-Infrequent Acess' => 'ONEZONE_IA',
+				'Glacier Instant Retrieval' => 'GLACIER_IR',
+				'Glacier Flexible Retrieval' => 'GLACIER',
+				'Glacier Deep Archive' => 'DEEP_ARCHIVE',
+				'Outpost' => 'OUTPOSTS',
+			];
 		if (empty($_GET['view'])) {
 			return load_view(__DIR__ . '/views/grid.php');
 		} else {
 			$config['regions'] = $regions;
+			$config['storageclasses'] = $storageclasses;
 			return load_view(__DIR__ . '/views/form.php', $config);
 		}
 	}
@@ -112,9 +125,14 @@ class S3 extends FlysystemBase
 		if (!empty($this->config['customendpoint'])) {
 			$config['endpoint'] = $this->config['customendpoint'];
 		}
+
+		$adapterOptions = [
+			'StorageClass' => $this->config['storageclass']
+		];
+
 		$client = new S3Client($config);
 		// Decorate the adapter
-		$adapter = new AwsS3V3Adapter($client, $this->config['bucket'], $this->config['path']);
+		$adapter = new AwsS3V3Adapter($client, $this->config['bucket'], $this->config['path'], null, null, $adapterOptions);
 		$this->handler = new Filesystem($adapter);
 		return $this->handler;
 	}

--- a/drivers/S3/views/form.php
+++ b/drivers/S3/views/form.php
@@ -149,6 +149,30 @@ $fstype = isset($fstype) ? $fstype : 'auto';
 										</div>
 									</div>
 									<!--END AWS Secret-->
+									<!--Storage Class-->
+									<div class="element-container">
+										<div class="row">
+											<div class="form-group">
+												<div class="col-md-3">
+													<label class="control-label" for="storageclass"><?php echo _("Storage Class") ?></label>
+												</div>
+												<div class="col-md-9">
+													<div class="input-group">
+														<select class="form-control" id="storageclass" name="storageclass">
+															<?php
+															foreach ($storageclasses as $value => $key) {
+																$selected = ($key == $storageclass) ? 'SELECTED' : '';
+													    		echo '<option value = "' . $key . '" ' . $selected . '>' . $value . '</option>';
+															}
+															?>
+														</select>
+														<span class="input-group-addon" id="storageclassaddon"><a href="https://aws.amazon.com/s3/storage-classes/" target="_blank"><?php echo _("What's this?") ?></a></span>
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+									<!--END Storage Class-->
 									<!--Path-->
 									<div class="element-container">
 										<div class="row">


### PR DESCRIPTION
This commit allows users to specify which S3 storage class they would like their files uploaded to. Useful for backups as glacier instant retrieval is sufficient in most situations. Saves on the cost that amazon charges to change storage class via lifecycle rules.