### PR TITLE
FREEI-2035 GQL API : Setting enabled param to default yes, when not set.

### DIFF
--- a/Api/Gql/Filestore.php
+++ b/Api/Gql/Filestore.php
@@ -188,7 +188,7 @@ class Filestore extends Base {
 	private function getFTPInputFields() {
 		return [
 			'enabled' => [
-				'type' => Type::nonNull(Type::boolean()),
+				'type' => Type::boolean(),
 				'description' => _('Enabled FTP.')
 			],
 			'serverName' => [
@@ -246,7 +246,7 @@ class Filestore extends Base {
 				'description' => _('Enter the ID for FTP')
 			],
 			'enabled' => [
-				'type' => Type::nonNull(Type::boolean()),
+				'type' => Type::boolean(),
 				'description' => _('Enabled FTP.')
 			],
 			'serverName' => [
@@ -544,7 +544,7 @@ class Filestore extends Base {
 	 * @return void
 	 */
 	private function resolveFTPNames($input){
-		$input["enabled"]= isset($input["enabled"]) && $input["enabled"] === true ? "yes" : "no";
+		$input["enabled"] = (((!isset($input["enabled"])) || (isset($input["enabled"]) && $input["enabled"] === true)) ? "yes" : "no");
 		$input['name']  = $input['serverName'];
 		$input['host']  = $input['hostName'];
 		$input['user']  = $input['userName'];
@@ -553,7 +553,6 @@ class Filestore extends Base {
 		$input['path']  = isset($input['path']) ? $input['path'] : '/';
 		$input['transfer']  = isset($input['transfer']) ? $input['transfer'] : 'passive';
 		$input['timeout']  = isset($input['timeout']) ? $input['timeout'] : 30;
-
 		return $input;
 	}
 	
@@ -583,8 +582,7 @@ class Filestore extends Base {
 	private function FTPUpdateFields($input){
 		$input['id'] = ltrim($input['id'],'FTP_');
 		$res = $this->freepbx->filestore->getItemById($input['id']);
-		
-		$input["enabled"]= isset($input["enabled"]) && $input["enabled"] === true ? "yes" : "no";
+		$input["enabled"] = (((!isset($input["enabled"])) || (isset($input["enabled"]) && $input["enabled"] === true)) ? "yes" : "no");
 		$input['name']  = isset($input['serverName']) ? $input['serverName'] : $res['name'];
 		$input['host']  = isset($input['hostName']) ? $input['hostName'] : $res['host'];
 		$input['user']  = isset($input['userName']) ? $input['userName'] : $res['user'];


### PR DESCRIPTION
This PR fixes a GraphQL error that occurs when the enabled parameter is not set in the addFTPInstance and updateFTPInstance mutations.

The issue was introduced in the following commit:
https://github.com/FreePBX/filestore/commit/b619c4b47c959252d295543d3ae90616ebcc419b#diff-65a633a07f98aad18b80a2790b8bb5493a9c9dd85d06f4b63207198062619bf4R191